### PR TITLE
Add usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ To use this data for supervised machine learning, train the model on the data in
 
 You're free to use this data for academic purposes, provided you [cite this work](https://zenodo.org/record/3986905#.XzrIsxNKhBw).
 
+## Example programs
+
+The `examples` directory contains small sample scripts. `list_videos.py` counts the number of videos per trick, and `sample_video_to_frames.py` extracts a few frames from a video.
+
 
 ## Details
 

--- a/examples/list_videos.py
+++ b/examples/list_videos.py
@@ -1,0 +1,14 @@
+import os
+from collections import defaultdict
+
+BASE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Tricks')
+
+video_counts = defaultdict(int)
+for root, dirs, files in os.walk(BASE_DIR):
+    for fname in files:
+        if fname.lower().endswith('.mov'):
+            label = os.path.basename(root)
+            video_counts[label] += 1
+
+for label, count in sorted(video_counts.items()):
+    print(f'{label}: {count} videos')

--- a/examples/sample_video_to_frames.py
+++ b/examples/sample_video_to_frames.py
@@ -1,0 +1,30 @@
+"""Sample frames from a video in the Tricks directory.
+Saves the first few frames as JPEG images.
+"""
+import cv2
+import os
+import sys
+
+BASE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'Tricks')
+
+if len(sys.argv) < 2:
+    print('Usage: python sample_video_to_frames.py <relative/path/to/video.mov>')
+    sys.exit(1)
+
+video_path = os.path.join(BASE_DIR, sys.argv[1])
+
+if not os.path.exists(video_path):
+    sys.exit(f'Video not found: {video_path}')
+
+cap = cv2.VideoCapture(video_path)
+
+frame_id = 0
+while frame_id < 5:  # save first 5 frames
+    ret, frame = cap.read()
+    if not ret:
+        break
+    out_name = f'frame_{frame_id:03d}.jpg'
+    cv2.imwrite(out_name, frame)
+    print('Saved', out_name)
+    frame_id += 1
+cap.release()


### PR DESCRIPTION
## Summary
- add simple example scripts for counting videos and saving frames
- document new examples in README

## Testing
- `python -m py_compile examples/list_videos.py examples/sample_video_to_frames.py MLScript.py PopulateTrainTest.py`

------
https://chatgpt.com/codex/tasks/task_e_6854dd917a308322a9a52dd32ca9371e